### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -6,6 +6,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+permissions:
+  contents: read
 jobs:
   build:
     name: Ansible Lint # Naming the build is important to use it as a status check


### PR DESCRIPTION
Potential fix for [https://github.com/andre-gonzalez/ansible/security/code-scanning/1](https://github.com/andre-gonzalez/ansible/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root in `.github/workflows/ansible-lint.yml` so all jobs inherit least-privilege token access by default.

Best single fix without changing functionality:
- Insert:
  - `permissions:`
  - `contents: read`
- Place it near the top-level keys (after `on:` block and before `jobs:` is a clear/common location).
- No imports, methods, or dependencies are needed (YAML config only).

This preserves existing behavior for checkout/lint while ensuring `GITHUB_TOKEN` is not over-privileged by default.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
